### PR TITLE
Support for AFNetworking 2.0.0

### DIFF
--- a/MACachedImageView.podspec
+++ b/MACachedImageView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "MACachedImageView"
-  s.version      = "1.1.1"
+  s.version      = "1.1.2"
   s.summary      = "Load images from a URL into a local cache before displaying them and show a fancy loading indicator in the meantime."
   s.homepage     = "https://github.com/swissmanu/MACachedImageView"
   s.author       = { "Manuel Alabor" => "msites@msites.net" }
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
 
   s.platform     = :ios, '6.0'
   s.source_files = 'MACachedImageView/MACachedImageView.{h,m}','MACachedImageView/NSString+MD5.{h,m}'
-  s.dependency     'AFNetworking', '~> 1.3.0'
+  s.dependency     'AFNetworking', '~> 2.0.0'
   s.dependency     'MACircleProgressIndicator', '~> 1.0.0'
   s.requires_arc = true
 end

--- a/MACachedImageView/MACachedImageView.h
+++ b/MACachedImageView/MACachedImageView.h
@@ -1,6 +1,6 @@
 
 #import <UIKit/UIKit.h>
-#import <AFNetworking.h>
+#import <AFHTTPRequestOperation.h>
 #import <MACircleProgressIndicator.h>
 
 @interface MACachedImageView : UIImageView

--- a/Podfile
+++ b/Podfile
@@ -1,3 +1,3 @@
 platform :ios, '6.0'
-pod 'AFNetworking', '~> 1.3.0'
+pod 'AFNetworking', '~> 2.0.0'
 pod 'MACircleProgressIndicator', '~> 1.0.0'


### PR DESCRIPTION
Updated podspec and podfile for the new version of AFNetworking
Header file now uses AFHTTPRequestOperation instead of all of the
AFNetworking library
