### PR TITLE
Update AFNetworking dependency to 2.2.0

### DIFF
--- a/MACachedImageView.podspec
+++ b/MACachedImageView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "MACachedImageView"
-  s.version      = "1.1.2"
+  s.version      = "1.1.3"
   s.summary      = "Load images from a URL into a local cache before displaying them and show a fancy loading indicator in the meantime."
   s.homepage     = "https://github.com/swissmanu/MACachedImageView"
   s.author       = { "Manuel Alabor" => "msites@msites.net" }
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
 
   s.platform     = :ios, '6.0'
   s.source_files = 'MACachedImageView/MACachedImageView.{h,m}','MACachedImageView/NSString+MD5.{h,m}'
-  s.dependency     'AFNetworking', '~> 2.0.0'
+  s.dependency     'AFNetworking', '~> 2.2.0'
   s.dependency     'MACircleProgressIndicator', '~> 1.0.0'
   s.requires_arc = true
 end

--- a/MACachedImageView/MACachedImageView.m
+++ b/MACachedImageView/MACachedImageView.m
@@ -187,7 +187,7 @@
         
         AFHTTPRequestOperation *operation = [[AFHTTPRequestOperation alloc] initWithRequest:req];
         operation.outputStream = [NSOutputStream outputStreamToFileAtPath:destinationPath append:NO];
-        [operation setDownloadProgressBlock:^(NSUInteger bytesRead, long long totalBytesRead, long long totalBytesExpectedToRead) {
+        [operation setDownloadProgressBlock:^(NSUInteger bytesRead, NSInteger totalBytesRead, NSInteger totalBytesExpectedToRead) {
             float progress = (float)totalBytesRead / (float)totalBytesExpectedToRead;
             if(progressIndicator) progressIndicator.value = progress;
         }];

--- a/Podfile
+++ b/Podfile
@@ -1,3 +1,3 @@
 platform :ios, '6.0'
-pod 'AFNetworking', '~> 2.0.0'
+pod 'AFNetworking', '~> 2.2.0'
 pod 'MACircleProgressIndicator', '~> 1.0.0'


### PR DESCRIPTION
- updated podspec and pod file for 2.2.0 of AFNetworking
- setDownloadProgressBlock now uses NSInteger instead of 'long long'
